### PR TITLE
[fix] handle create term summary

### DIFF
--- a/src/modules/term-summary/term-summary.usecase.ts
+++ b/src/modules/term-summary/term-summary.usecase.ts
@@ -232,6 +232,10 @@ export class TermSummaryUseCase {
       r => r.studyYearInRegis === studyYear && r.studyTermInRegis === studyTerm
     );
 
+    if (registerInTerm.length === 0) {
+      return null;
+    }
+
     const creditTerm = registerInTerm.reduce(
       (sum, r) => sum + (r.gradeCharacter === 'F' ? 0 : (r.creditRegis ?? 0)),
       0


### PR DESCRIPTION

<img width="1402" height="179" alt="image" src="https://github.com/user-attachments/assets/15f990a4-83a8-4815-bb2b-3f4495ca9231" />


- เกิดจาก สร้างแล้วมีเทอม ที่ไม่ได้ลงทะเบียนแล้วให้ไปสร้าง มันเลยเข้าถึง register ที่ไม่มีเลยระเบิด

<img width="876" height="643" alt="image" src="https://github.com/user-attachments/assets/4f0c95e3-9de9-4734-a7a0-4d9aabc4e132" />
